### PR TITLE
spelling error in migration fix on remeber me

### DIFF
--- a/luckydog/app/controllers/application_controller.rb
+++ b/luckydog/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   def current_user
-  	@current_user ||= User.find_by_rememeber_me(cookies[:rememeber_me]) if cookies[:rememeber_me]
+  	@current_user ||= User.find_by_remember_me(cookies[:remember_me]) if cookies[:remember_me]
   end
   helper_method :current_user
 

--- a/luckydog/app/controllers/sessions_controller.rb
+++ b/luckydog/app/controllers/sessions_controller.rb
@@ -7,10 +7,10 @@ class SessionsController < ApplicationController
 		user = User.find_by(email: params[:session][:email].downcase)
 		# If user exists AND the password is correct
 		if user && user.authenticate(params[:session][:password])
-			if params[:rememeber_me]
-				cookies.permanent[:rememeber_me] = user.rememeber_me
+			if params[:remember_me]
+				cookies.permanent[:remember_me] = user.remember_me
 			else
-				cookies[:rememeber_me] = user.rememeber_me
+				cookies[:remember_me] = user.remember_me
 			end
 			# Save the user id inside the browser cookie. This is how we keep the user
 			# logged in when they navigate to around the luckydog site
@@ -23,7 +23,7 @@ class SessionsController < ApplicationController
 	end
 
 	def destroy
-		cookies.delete(:rememeber_me)
+		cookies.delete(:remember_me)
 		redirect_to '/'
 	end
 

--- a/luckydog/app/controllers/users_controller.rb
+++ b/luckydog/app/controllers/users_controller.rb
@@ -12,7 +12,7 @@ class UsersController < ApplicationController
 	def create
 		user = User.new(user_params)
 		if user.save
-			cookies.permanent[:rememeber_me] = user.rememeber_me
+			cookies.permanent[:remember_me] = user.remember_me
 			redirect_to '/'
 		else
 			flash[:error] = "An error occured"
@@ -22,7 +22,7 @@ class UsersController < ApplicationController
 
 private
 	def user_params
-		params.require(:user).permit(:name, :email, :password, :password_confirmation, :rememeber_me)
+		params.require(:user).permit(:name, :email, :password, :password_confirmation, :remember_me)
 	end
 
 end

--- a/luckydog/app/models/user.rb
+++ b/luckydog/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ActiveRecord::Base
 
 	has_secure_password
 	validates_presence_of :password, :on => :create
-	before_create {generate_token(:rememeber_me) }
+	before_create {generate_token(:remember_me) }
 
 	def generate_token(column)
 		begin

--- a/luckydog/app/views/sessions/new.html.erb
+++ b/luckydog/app/views/sessions/new.html.erb
@@ -11,8 +11,8 @@
 	      <%= f.label :password %>
 	      <%= f.password_field :password, class: 'form-control' %>
 
-	      <%= f.label :rememeber_me %>
-	      <%= check_box_tag :rememeber_me, 1, params[:rememeber_me] %>
+	      <%= f.label :remember_me %>
+	      <%= check_box_tag :remember_me, 1, params[:remember_me] %>
 	      <br>
 
 	      <%= f.submit "Log in", class: "btn btn-primary" %>

--- a/luckydog/db/migrate/20160606165022_change_column_remember_me_in_users_to_remember_me.rb
+++ b/luckydog/db/migrate/20160606165022_change_column_remember_me_in_users_to_remember_me.rb
@@ -1,0 +1,5 @@
+class ChangeColumnRememberMeInUsersToRememberMe < ActiveRecord::Migration
+  def change
+  	rename_column :users, :rememeber_me, :remember_me
+  end
+end

--- a/luckydog/db/schema.rb
+++ b/luckydog/db/schema.rb
@@ -11,10 +11,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160524165457) do
+ActiveRecord::Schema.define(version: 20160606165022) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "uploads", force: :cascade do |t|
+    t.string   "url"
+    t.string   "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string   "name"
@@ -22,7 +29,7 @@ ActiveRecord::Schema.define(version: 20160524165457) do
     t.string   "password_digest"
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
-    t.string   "rememeber_me"
+    t.string   "remember_me"
   end
 
 end


### PR DESCRIPTION
I misspelled remember_me in the migration so I changed it by doing `rails g migration ChangeRememberMeInUsersToRememberMe` and added a `rename_column: :users, :rememeber_me, :remember_me` 

Then did a rake db:migrate
